### PR TITLE
Ported turf measurement center function

### DIFF
--- a/turf/src/commonMain/kotlin/io/github/dellisd/spatialk/turf/Measurement.kt
+++ b/turf/src/commonMain/kotlin/io/github/dellisd/spatialk/turf/Measurement.kt
@@ -231,7 +231,7 @@ fun bbox(geometry: MultiPolygon) = computeBbox(geometry.coordAll())
  * @return A [BoundingBox] that covers the geometry.
  */
 @ExperimentalTurfApi
-fun bbox(feature: Feature): BoundingBox? = computeBbox(feature.coordAll() ?: emptyList())
+fun bbox(feature: Feature): BoundingBox = computeBbox(feature.coordAll() ?: emptyList())
 
 /**
  * Takes a feature collection and calculates a bbox that covers all features in the collection.
@@ -462,4 +462,29 @@ fun midpoint(point1: Position, point2: Position): Position {
     val heading = bearing(point1, point2)
 
     return destination(point1, dist / 2, heading)
+}
+
+/**
+ * Takes any kind of [Feature] and returns the center point. It will create a [BoundingBox] around the given
+ * [Feature] and calculates the center point of it.
+ *
+ * @param feature the feature to find the center for
+ * @return A [Point] holding the center coordinates
+ */
+@ExperimentalTurfApi
+fun center(feature: Feature): Point {
+    val ext = bbox(feature)
+    val x = (ext.southwest.longitude + ext.northeast.longitude) / 2
+    val y = (ext.southwest.latitude + ext.northeast.latitude) / 2
+    return Point(Position(longitude = x, latitude = y))
+}
+
+/**
+ * It overloads the center(feature: Feature) method.
+ *
+ * @param geometry the [Geometry] to find the center for
+ */
+@ExperimentalTurfApi
+fun center(geometry: Geometry): Point {
+    return center(Feature(geometry = geometry))
 }

--- a/turf/src/commonTest/kotlin/io/github/dellisd/spatialk/turf/TurfMeasurementTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/dellisd/spatialk/turf/TurfMeasurementTest.kt
@@ -1,9 +1,9 @@
 @file:Suppress("MagicNumber")
 
 package io.github.dellisd.spatialk.turf
-
 import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.LineString
+import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Polygon
 import io.github.dellisd.spatialk.geojson.Position
@@ -120,5 +120,25 @@ class TurfMeasurementTest {
 
         assertDoubleEquals(-76.6311, midpoint.longitude, 0.0001)
         assertDoubleEquals(42.2101, midpoint.latitude, 0.0001)
+    }
+
+    @Test
+    fun testCenterFromFeature() {
+        val geometry = Polygon.fromJson(readResource("measurement/area/other.json"))
+
+        val centerPoint = center(Feature(geometry))
+
+        assertDoubleEquals(-75.71805238723755, centerPoint.coordinates.longitude, 0.0001)
+        assertDoubleEquals(45.3811030151199, centerPoint.coordinates.latitude, 0.0001)
+    }
+
+    @Test
+    fun testCenterFromGeometry() {
+        val geometry = Polygon.fromJson(readResource("measurement/area/other.json"))
+
+        val centerPoint = center(geometry)
+
+        assertDoubleEquals(-75.71805238723755, centerPoint.coordinates.longitude, 0.0001)
+        assertDoubleEquals(45.3811030151199, centerPoint.coordinates.latitude, 0.0001)
     }
 }


### PR DESCRIPTION
issue#4 fix suggestion

I ported the JS turf **center** function into `Measurement.kt` class and added a simple test

Visually I confirmed the output [here](https://geojson.io/#map=13.61/45.38111/-75.71805). Testfile GeoJson is on [gist](https://gist.github.com/P72B/cc66c60485eb2375789b673fc29f8cf0).
<img width="1277" alt="2023 09 27 turf center" src="https://github.com/dellisd/spatial-k/assets/2487501/4c4dab7a-e811-4236-a2b6-73b219549a01">
